### PR TITLE
Fix loop initial declarations

### DIFF
--- a/ext/consistent_hash/consistent_hash.c
+++ b/ext/consistent_hash/consistent_hash.c
@@ -2,8 +2,9 @@
 
 VALUE consistent_hash(VALUE string) {
   uint32_t h = 0;
+  int i;
 
-  for (int i = 0; i < RSTRING_LEN(string); i++) {
+  for (i = 0; i < RSTRING_LEN(string); i++) {
     uint32_t c = RSTRING_PTR(string)[i];
     h = h * 31 + c;
   }


### PR DESCRIPTION
We were getting following error on Ubuntu 14.04 (Trusty)

```
compiling consistent_hash.c
consistent_hash.c: In function ‘consistent_hash’:
consistent_hash.c:6:3: error: ‘for’ loop initial declarations are only allowed in C99 mode
   for (int i = 0; i < RSTRING_LEN(string); i++) {
   ^
consistent_hash.c:6:3: note: use option -std=c99 or -std=gnu99 to compile your code
make: *** [consistent_hash.o] Error 1

make failed, exit code 2
```